### PR TITLE
Use returns option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ import { comment } from './jsdocer';
 import { parse } from './commentContinuer';
 
 const BETA_KEY = 'atom-easy-jsdoc.beta';
+const USE_RETURNS_KEY = 'atom-easy-jsdoc.useReturns';
 
 const regexJsDoc = require('./regex/jsdoc');
 
@@ -19,7 +20,7 @@ function createComment() {
   const code = editor.getText();
   const { row } = editor.getCursorBufferPosition();
   const lineNum = row + 1;
-  const { content, line } = comment(code, lineNum);
+  const { content, line } = comment(code, lineNum, atom.config.get(USE_RETURNS_KEY));
   editor.setCursorBufferPosition([(line - 1), 0]);
   editor.insertText(`\n${content}`);
 }
@@ -50,7 +51,7 @@ export function activate() {
       if (atom.config.get(BETA_KEY)) {
         createComment();
       } else {
-        regexJsDoc.block();
+        regexJsDoc.block(atom.config.get(USE_RETURNS_KEY));
       }
     },
     'editor:newline': () => {
@@ -63,17 +64,29 @@ export function activate() {
   });
 }
 
-const description = [
+const betaDescription = [
   'This is a complete rewrite and uses an abstract syntax tree instead of regular expressions.',
   'It adds support for ES 2015 function parameters and exports.',
   'More features are coming...',
 ];
 
+const returnsDescription = [
+  'JSDoc could not make a decision as to which to use, @return or @returns so allow both.',
+  'Eslint valid JSDoc expects @returns so you can enable this here.',
+  'This will default to true after version 5.',
+];
+
 export const config = {
+  useReturns: {
+    type: 'boolean',
+    default: false,
+    title: 'Use @returns instead of @return',
+    description: returnsDescription.join(' '),
+  },
   beta: {
     type: 'boolean',
     default: false,
     title: 'Enable Beta',
-    description: description.join(' '),
+    description: betaDescription.join(' '),
   },
 };

--- a/lib/jsdocer.js
+++ b/lib/jsdocer.js
@@ -136,12 +136,14 @@ function getIndent(node) {
  * comment.
  *
  * @param {Object} node AST repreentation of function node
+ * @param {boolean} useReturns Use returns instead of return
  *
  * @returns {String} JS Doc comment representing the function node.
  */
-function buildContent(node) {
+function buildContent(node, useReturns) {
   const params = makeParams(node.params);
   const indent = getIndent(node);
+  const returnKey = useReturns ? 'returns' : 'return';
   if (params.length > 0) {
     params.push(' *');
   }
@@ -151,7 +153,7 @@ function buildContent(node) {
     ' *',
   ];
   const returns = [
-    ' * @returns {type} Description',
+    ` * @${returnKey} {type} Description`,
     ' */',
   ];
 
@@ -167,12 +169,13 @@ function buildContent(node) {
  * insert the comment at.
  *
  * @param {Object} node AST node representing the function being commented.
+ * @param {boolean} useReturns When enabled uses the returns return type
  *
  * @returns {Object} Containing content (JS Doc comment) and line to insert the
  * comment.
  */
-function buildResult(node) {
-  const content = buildContent(node);
+function buildResult(node, useReturns) {
+  const content = buildContent(node, useReturns);
   const line = node.loc.start.line - 1;
   return {
     content,
@@ -229,13 +232,14 @@ function getNode(code, lineNum) {
  *
  * @param {String} code     Code containing the function.
  * @param {int} [lineNum=1] Line number containing the
+ * @param {boolean} [useReturns=false] Use returns style of JSDoc comment
  *
  * @returns {Object|String} Object containing the comment or an empty string.
  */
-export function comment(code, lineNum = 1) {
+export function comment(code, lineNum = 1, useReturns = false) {
   const node = getNode(code, lineNum);
   if (node) {
-    return buildResult(node);
+    return buildResult(node, useReturns);
   }
   return '';
 }

--- a/lib/regex/commentator.js
+++ b/lib/regex/commentator.js
@@ -13,7 +13,7 @@ var METHOD_ARGS = /(\w+)[\s+]?[^\(]*\(\s*([^\)]*)\)[\s]?\{/m
  * @param   {string} fnName  - The name of the function if non-anonymous
  * @returns {Array}            The jsdoc style comment in a line by line array.
  */
-function buildCommentString (fnArgs, fnName) {
+function buildCommentString (fnArgs, fnName, useReturns) {
     if (!fnName) {
         fnName = 'anonymous function';
     }
@@ -27,7 +27,8 @@ function buildCommentString (fnArgs, fnName) {
         longestArgLength = fnArgs.reduce(function (prevLength, current, index) {
             current = fnArgs[index] = current.trim();
             return prevLength > current.length ? prevLength : current.length;
-        }, 0);
+        }, 0),
+        returnKey = useReturns ? 'returns' : 'return';
 
     comment.push('/**');
     comment.push(startLine + fnName + ' - description');
@@ -41,7 +42,7 @@ function buildCommentString (fnArgs, fnName) {
         }
     });
 
-    comment.push(startLine + '@return {type} ' + new Array(longestArgLength+1).join(' ') + ' description');
+    comment.push(startLine + '@' + returnKey + ' {type} ' + new Array(longestArgLength+1).join(' ') + ' description');
     comment.push(' */');
 
     return comment;
@@ -81,13 +82,13 @@ module.exports = {
      * @param   {string} nextLine     - The line immediately following the current line.
      * @returns {Object}                An object with a comment type field (FUNCTION or EMPTY) enum and an array of comment line strings.
      */
-    makeComment: function (currentLine, nextLine) {
+    makeComment: function (currentLine, nextLine, useReturns) {
         var declaration = parseFunctionDeclaration(nextLine);
 
         // If the next line is a declaration, lets handle it and if not just return a plain old comment.
         if (declaration) {
             return {
-                lines: buildCommentString(declaration[2].split(','), declaration[1]),
+                lines: buildCommentString(declaration[2].split(','), declaration[1], useReturns),
                 type: 'FUNCTION'
             };
         }

--- a/lib/regex/jsdoc.js
+++ b/lib/regex/jsdoc.js
@@ -53,8 +53,7 @@ function continueComments (editor) {
  *
  * @return undefined
  */
-function writeBlock () {
-    console.log('REGEX BLOCK');
+function writeBlock (useReturns) {
     var editor = atom.workspace.getActivePaneItem(),
         initialCursorPosition = editor.getCursorBufferPosition(),
         commentStart = initialCursorPosition.row + 1,
@@ -83,7 +82,7 @@ function writeBlock () {
     }
 
     // Generate the comment off of the current and next lines
-    comment = commentator.makeComment(thisLine, nextLine);
+    comment = commentator.makeComment(thisLine, nextLine, useReturns);
     commentLines = comment.lines;
     commentType = comment.type;
 

--- a/tests/jsdocer.test.js
+++ b/tests/jsdocer.test.js
@@ -10,7 +10,7 @@ describe('Commentator', () => {
       const doc = `/**
  * helloWorld - Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
 
       comment(code).content.should.equal(doc);
@@ -25,7 +25,7 @@ describe('Commentator', () => {
  * @param {type} b Description
  * @param {type} c Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
 
       comment(code).content.should.equal(doc);
@@ -40,7 +40,7 @@ describe('Commentator', () => {
  * @param {type} longParameter Description
  * @param {type} c             Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
 
       comment(code).content.should.equal(doc);
@@ -59,7 +59,7 @@ function helloWorld(a, b, c) {}
  * @param {type} b Description
  * @param {type} c Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
 
       comment(code, 4).content.should.equal(doc);
@@ -78,7 +78,7 @@ function helloWorld(a, b, c) {}
  * @param {type} b Description
  * @param {type} c Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
 
       comment(code, 3).content.should.equal(doc);
@@ -104,7 +104,7 @@ function helloWorld(a, b, c) {}
        * @param {type} b Description
        * @param {type} c Description
        *
-       * @returns {type} Description
+       * @return {type} Description
        */`;
       comment(code).content.should.equal(doc);
     });
@@ -120,7 +120,7 @@ function helloWorld(a, b, c) {}
  * @param {type} b Description
  * @param {type} c Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
 
       comment(code).content.should.equal(doc);
@@ -135,7 +135,7 @@ function helloWorld(a, b, c) {}
  * @param {type} b Description
  * @param {type} c Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
 
       comment(code).content.should.equal(doc);
@@ -148,7 +148,7 @@ function helloWorld(a, b, c) {}
  *
  * @param {type} [a=something] Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
 
       comment(code).content.should.equal(doc);
@@ -163,7 +163,7 @@ function helloWorld(a, b, c) {}
  * @param {type}   Unknown.a Description
  * @param {type}   Unknown.b Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
       comment(code).content.should.equal(doc);
     });
@@ -176,9 +176,23 @@ function helloWorld(a, b, c) {}
  * @param {type}  a Description
  * @param {Array} b Description
  *
- * @returns {type} Description
+ * @return {type} Description
  */`;
       comment(code).content.should.equal(doc);
+    });
+  });
+
+  describe('Configuration', () => {
+    it('should use @returns when useReturns is enabled', () => {
+      const code = 'function helloWorld(a) {}';
+      const doc = `/**
+ * helloWorld - Description
+ *
+ * @param {type} a Description
+ *
+ * @returns {type} Description
+ */`;
+      comment(code, 0, true).content.should.equal(doc);
     });
   });
 });


### PR DESCRIPTION
Allow for the user to control whether `@return` or `@returns` is output.
Unfortunately JSDoc standard never made a decision so we have to allow for
both.

After the switch is made (v5) to use the AST version all the time then
`@return` will become the default.