### PR TITLE
Line comment continuation removed

### DIFF
--- a/lib/commentContinuer.js
+++ b/lib/commentContinuer.js
@@ -3,10 +3,8 @@
 const BLOCK_COMMENT_RE = /^\s+\*[^\/]/i;
 const BLOCK_COMMENT_START_RE = /^\s*\/\*\*.*$/i;
 const BLOCK_COMMENT_END_RE = /.*\*\/\s?$/i;
-const LINE_COMMENT_RE = /^\s*\/\/.*$/i;
 
 const BLOCK_COMMENT = '* ';
-const LINE_COMMENT = '// ';
 
 /**
  * parse - Work out the type of comment on the line and return the appropriate
@@ -28,8 +26,6 @@ export function parse(commentLine) {
     return ` ${BLOCK_COMMENT}`;
   } else if (commentLine.match(BLOCK_COMMENT_RE)) {
     return BLOCK_COMMENT;
-  } else if (commentLine.match(LINE_COMMENT_RE)) {
-    return LINE_COMMENT;
   }
 
   return '';

--- a/tests/commentContinuer.test.js
+++ b/tests/commentContinuer.test.js
@@ -17,7 +17,7 @@ describe('Comment Parser', () => {
 
     it('should continue a line comment', () => {
       const line = '// here is some comment';
-      parse(line).should.equal('// ');
+      parse(line).should.equal('');
     });
 
     it('should not continue after a block comment is ended', () => {
@@ -53,7 +53,6 @@ describe('Comment Parser', () => {
     it('should continue comments where that have been indented multiple times', () => {
       parse('\t\t* hello').should.equal('* ');
       parse('\t\t/** hello').should.equal(' * ');
-      parse('\t\t// hello').should.equal('// ');
     });
   });
 });


### PR DESCRIPTION
It was added for legacy support but have had enough complaints that this should
go.

This resolves #14 