### PR TITLE
Null default values

### DIFF
--- a/lib/jsdoc/funcParser.js
+++ b/lib/jsdoc/funcParser.js
@@ -160,6 +160,9 @@ function parseAssignmentParam(param) {
   } else if (paramAssignmentType === 'ObjectExpression') {
     type = 'object';
     defaultValue = '{}';
+  } else if (paramAssignmentType === 'NullLiteral') {
+    type = 'null';
+    defaultValue = null;
   } else {
     throw new Error(`Unknown param type: ${paramAssignmentType}`);
   }

--- a/tests/unit/jsdoc/funcParser.test.js
+++ b/tests/unit/jsdoc/funcParser.test.js
@@ -181,6 +181,12 @@ function b() {}`;
         params.should.contain({ name: 'd', defaultValue: '[]', type: 'array' });
       });
 
+      it('should set the correct type for the default value - Array', () => {
+        const code = 'function helloWorld(d = null) {}';
+        const params = parse(code).params;
+        params.should.contain({ name: 'd', defaultValue: null, type: 'null' });
+      });
+
       it('should support rest parameters setting the type as array', () => {
         const code = 'function helloWorld(...stuff) {}';
         const params = parse(code).params;

--- a/tests/unit/jsdoc/renderer.test.js
+++ b/tests/unit/jsdoc/renderer.test.js
@@ -155,6 +155,24 @@ describe('JSDoc renderer', () => {
         render(structure).should.equal(doc);
       });
 
+      it('should show default null values', () => {
+        const structure = {
+          name: 'helloWorld',
+          params: [
+            { name: 'a', defaultValue: null },
+          ],
+          type: 'function',
+        };
+        const doc = `/**
+ * helloWorld - Description
+ *
+ * @param {type} [a=null] Description
+ *
+ * @return {type} Description
+ */`;
+        render(structure).should.equal(doc);
+      });
+
       it('should show parent name', () => {
         const structure = {
           name: 'helloWorld',


### PR DESCRIPTION
Null default values are parsed as NullLiterals and were previously
unhandled.

Fixes #37 