### PR TITLE
Handle `static` keyword for class methods

### DIFF
--- a/lib/jsdoc/funcParser.js
+++ b/lib/jsdoc/funcParser.js
@@ -22,6 +22,7 @@ const PARAM_PARSERS = {
 const SIMPLIFIERS = {
   'class': simplifyClassNode,
   'function': simplifyFuncNode,
+  'classMethod': simplifyClassMethodNode,
 };
 /* eslint-enable */
 
@@ -79,12 +80,21 @@ function getNode(ast, lineNum) {
         }
       }
     },
-    'ClassMethod|ObjectMethod': (declaration) => {
+    ObjectMethod: (declaration) => {
       if (node) { return; }
       const n = declaration.node;
       if (onLine(n, lineNum)) {
         node = n;
         node.jsDocType = 'function';
+        node.id = { name: node.key.name };
+      }
+    },
+    ClassMethod: (declaration) => {
+      if (node) { return; }
+      const n = declaration.node;
+      if (onLine(n, lineNum)) {
+        node = n;
+        node.jsDocType = 'classMethod';
         node.id = { name: node.key.name };
       }
     },
@@ -290,6 +300,22 @@ function simplifyNode(node) {
 function simplifyFuncNode(node) {
   return {
     params: simplifyParams(node.params),
+    returns: { returns: false },
+  };
+}
+
+
+/**
+ * simplifyClassMethodNode - Extract classMethod specific JS Doc properties.
+ *
+ * @param  {object} node AST representation of the node.
+ *
+ * @return {type}      Simplified representation of the node.
+ */
+function simplifyClassMethodNode(node) {
+  return {
+    params: simplifyParams(node.params),
+    isStatic: node.static,
     returns: { returns: false },
   };
 }

--- a/lib/jsdoc/renderer.js
+++ b/lib/jsdoc/renderer.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-use-before-define, quote-props */
 const CONTENT_BUILDERS = {
   'function': renderFuncContent,
+  'classMethod': renderFuncContent,
   'class': renderClassContent,
 };
 /* eslint-enable */
@@ -24,6 +25,21 @@ const LINE_PADDER = ' ';
 function padString(str, length) {
   const padding = ' '.repeat(length - str.length);
   return `${str}${padding}`;
+}
+
+/**
+ * renderNameLine - description
+ *
+ * @param  {Object} structure Object describing the JS Doc
+ * @return {String}           Name line for the JSDoc
+ */
+function renderNameLine(structure) {
+  const { name, type, description = 'Description', isStatic } = structure;
+  let nameLine = ` * ${name} - ${description}`;
+  if (type === 'classMethod' && isStatic) {
+    nameLine = ` * @static ${name} - ${description}`;
+  }
+  return nameLine;
 }
 
 /**
@@ -167,9 +183,9 @@ function renderClassContent(structure) {
  * @return {String} JS Doc comment
  */
 export function render(structure) {
-  const { name, description = 'Description', type, location = {} } = structure;
+  const { type, location = {} } = structure;
 
-  const nameLine = ` * ${name} - ${description}`;
+  const nameLine = renderNameLine(structure);
   const header = [OPEN];
   const footer = [CLOSE];
 

--- a/lib/regex/commentator.js
+++ b/lib/regex/commentator.js
@@ -4,7 +4,7 @@
 var FN_ARGS = /function\s(\w+)?[\s+]?[^\(]*\(\s*([^\)]*)\)/m;
 var PROTOTYPE_ARGS = /(\w+.prototype.\w+)\s*=\s*function\s{0,1}\(\s*([^\)]*)\)/m;
 var OBJECT_ARGS = /(\w+)\s*:\s*function\s{0,1}\(\s*([^\)]*)\)/m;
-var METHOD_ARGS = /(\w+)[\s+]?[^\(]*\(\s*([^\)]*)\)[\s]?\{/m
+var METHOD_ARGS = /(\w+[\s]?\w+)[\s+]?[^\(]*\(\s*([^\)]*)\)[\s]?\{/m;
 
 /**
  * buildCommentString - Build out a jsdoc style function comment from the provided inputs.
@@ -31,7 +31,13 @@ function buildCommentString (fnArgs, fnName, useReturns) {
         returnKey = useReturns ? 'returns' : 'return';
 
     comment.push('/**');
-    comment.push(startLine + fnName + ' - description');
+
+    // If a method modifier is present -> prepend an `@` symbol to `fnName`
+    if (fnName.indexOf('static') > -1) {
+      comment.push(startLine + '@' + fnName + ' - description');
+    } else {
+      comment.push(startLine + fnName + ' - description');
+    }
 
     comment.push(startLine);
 

--- a/tests/integration/jsdocer.test.js
+++ b/tests/integration/jsdocer.test.js
@@ -257,7 +257,7 @@ function helloWorld(a, b, c) {}
       });
 
       it('supports static methods', () => {
-        const doc = `/**
+        const doc = `  /**
    * @static Qux - Description
    *
    * @param {type} a Description

--- a/tests/integration/jsdocer.test.js
+++ b/tests/integration/jsdocer.test.js
@@ -233,6 +233,7 @@ function helloWorld(a, b, c) {}
     describe('classes', () => {
       const code = `class Foo extends Bar {
   Baz(a, b) {}
+  static Qux(a, b) {}
 }`;
 
       it('supports definitions', () => {
@@ -253,6 +254,18 @@ function helloWorld(a, b, c) {}
    * @return {type} Description
    */`;
         comment(code, 2).content.should.equal(doc);
+      });
+
+      it('supports static methods', () => {
+        const doc = `/**
+   * @static Qux - Description
+   *
+   * @param {type} a Description
+   * @param {type} b Description
+   *
+   * @return {type} Description
+   */`;
+        comment(code, 3).content.should.equal(doc);
       });
     });
   });

--- a/tests/unit/jsdoc/funcParser.test.js
+++ b/tests/unit/jsdoc/funcParser.test.js
@@ -226,11 +226,20 @@ function b() {}`;
         parse(code, 1).extends.should.equal('Bar');
       });
 
-      it('should create a normal function defintion for class methods', () => {
+      it('should create an extended function definition for class methods', () => {
         const code = `class Foo extends Bar {
           constructor() {}
         }`;
         parse(code, 2).name.should.equal('constructor');
+        parse(code, 2).type.should.equal('classMethod');
+        parse(code, 2).isStatic.should.equal(false);
+      });
+
+      it('should set the `isStatic` property for static class methods', () => {
+        const code = `class Foo extends Bar {
+          static myStaticMethod() {}
+        }`;
+        parse(code, 2).isStatic.should.equal(true);
       });
 
       it('should not barf at class properties', () => {

--- a/tests/unit/jsdoc/renderer.test.js
+++ b/tests/unit/jsdoc/renderer.test.js
@@ -237,6 +237,21 @@ describe('JSDoc renderer', () => {
  */`;
         render(structure).should.equal(doc);
       });
+
+      it('renders class methods with their modifier keywords', () => {
+        const structure = {
+          name: 'helloStatic',
+          type: 'classMethod',
+          isStatic: true,
+        };
+
+        const doc = `/**
+ * @static helloStatic - Description
+ *
+ * @return {type} Description
+ */`;
+        render(structure).should.equal(doc);
+      });
     });
   });
 });


### PR DESCRIPTION
Currently the class method signature
```
static foo(a, b) {}
```
generates the following JSDoc from both the default regex substitution and the beta AST parsing:
```
  /**
   * foo - Description
   *
   * @param {type} a Description
   * @param {type} b Description
   *
   * @return {type} Description
   */
```

In order to correctly label `static` class methods (and provide extensibility for ES7+ proposals such as `async`) this PR adds the ability to detect the `static` keyword via regex substitution and/or AST parsing, as well as adding relevant unit & integration tests.

The JSDoc output for the method signature above would look as follows post-merge:

```
  /**
   * @static foo - Description
   *
   * @param {type} a Description
   * @param {type} b Description
   *
   * @return {type} Description
   */
```