### PR TITLE
add install instructions using apm

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 Atom package for quick jsdoc comment generation.
 Forked from [Atom JS Doc by Craig Offutt](https://github.com/coffutt/atom-jsdoc)
 
+## Install
+
+```bash
+apm install atom-easy-jsdoc
+```
+
 ## Usage
 
 Control-Shift-d or Control-Shift-j to add comment templates.


### PR DESCRIPTION
It seems obvious to install the package from the github repo name but since it's not always the case I had to go back to the atom.io package to confirm the name before running `apm install atom-easy-jsdoc`. In the grand scheme of things it's not a big deal but I like the reassurance of seeing the command to install packages in the package README.

I'm definitely open to moving the install section below the usage section since it's pretty trivial.