### PR TITLE
Replace 'javadoc' on line 31 with 'jsdoc'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To add comments for any piece of code, position the cursor anywhere on the line 
  * @return {type}      description
  */
 function functionComment (argA, argB, argC) {
-    return 'javadoc';
+    return 'jsdoc';
 }
 ```
 


### PR DESCRIPTION
It would make more sense to use the word jsdoc rather than javadoc.